### PR TITLE
Migrate TravisCI config to GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+  push:
+
+jobs:
+  npm-test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install --save-dev
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-  - "lts/*"


### PR DESCRIPTION
This commit removes the Travis config and replaces it with a GitHub actions workflow, which is standard for dxw repositories.

See:
    https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

Note that we only support versions of Node that are in long term support, and since there is no lock file here, we use npm install, rather than npm ci.

See:
    https://endoflife.date/nodejs